### PR TITLE
Add pictures across pages

### DIFF
--- a/Contact.html
+++ b/Contact.html
@@ -39,6 +39,7 @@
             <h2 class="section-title">Always feel free to contact me at</h2>
             <p>drapertait@gmail.com</p>
             <img src="my pic.jpg" class="img-fluid mt-4" style="max-width: 300px;" alt="Photo of Tait">
+            <img src="vintage phone.jpg" class="img-fluid mt-4" style="max-width: 300px;" alt="Vintage phone">
         </div>
     </section>
 

--- a/Projects.html
+++ b/Projects.html
@@ -49,6 +49,9 @@
                 <div class="col-md-4 mb-4"><img src="code p4.png" class="img-fluid" alt="Project screenshot"></div>
                 <div class="col-md-4 mb-4"><img src="code p5.png" class="img-fluid" alt="Project screenshot"></div>
                 <div class="col-md-4 mb-4"><img src="code p6.png" class="img-fluid" alt="Project screenshot"></div>
+                <div class="col-md-4 mb-4"><img src="code p7.png" class="img-fluid" alt="Project screenshot"></div>
+                <div class="col-md-4 mb-4"><img src="code p8.png" class="img-fluid" alt="Project screenshot"></div>
+                <div class="col-md-4 mb-4"><img src="code p9.png" class="img-fluid" alt="Project screenshot"></div>
             </div>
         </div>
     </section>

--- a/Skills.html
+++ b/Skills.html
@@ -37,6 +37,9 @@
     <section>
         <div class="container" data-aos="fade-up">
             <h2 class="section-title text-center">Technical Skills</h2>
+            <div class="text-center mb-4">
+                <img src="programming-languages-1.jpg.webp" class="img-fluid" alt="Programming languages illustration">
+            </div>
             <div class="skills-list">
                 <div class="skill-item">
                     <div class="skill-name">Python</div>

--- a/index.html
+++ b/index.html
@@ -35,6 +35,20 @@
         </div>
     </section>
 
+    <section id="gallery">
+        <div class="container" data-aos="fade-up">
+            <h2 class="section-title text-center">Gallery</h2>
+            <div class="row">
+                <div class="col-md-6 mb-4 text-center">
+                    <img src="brown balls.png" class="img-fluid rounded" alt="Abstract design">
+                </div>
+                <div class="col-md-6 mb-4 text-center">
+                    <img src="old phone.webp" class="img-fluid rounded" alt="Vintage phone">
+                </div>
+            </div>
+        </div>
+    </section>
+
     <section id="skills">
         <div class="container text-center" data-aos="fade-up">
             <h2 class="section-title">My Skills</h2>


### PR DESCRIPTION
## Summary
- add a small gallery section with two images on the homepage
- include an illustration in the skills page
- show additional screenshots on the projects page
- add another picture to the contact page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fa0213f14832583b4d8809f9f8fcc