### PR TITLE
Expand homepage section heights

### DIFF
--- a/Stylesheet.css
+++ b/Stylesheet.css
@@ -119,3 +119,21 @@ footer p {
 .progress .color-cpp { background-color: #2ecc71; }
 .progress .color-json { background-color: #16a085; }
 .progress .color-xml { background-color: #6ab04c; }
+
+/* Specific sizing for the homepage background images */
+.home-hero {
+    min-height: 70vh;
+}
+
+.home-section {
+    min-height: 50vh;
+}
+
+@media (max-width: 768px) {
+    .home-hero {
+        min-height: 60vh;
+    }
+    .home-section {
+        min-height: 40vh;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
         </div>
     </nav>
 
-    <section class="hero" style="background-image: url('https://images.unsplash.com/photo-1503264116251-35a269479413?auto=format&fit=crop&w=1500&q=80');">
+    <section class="hero home-hero" style="background-image: url('https://images.unsplash.com/photo-1503264116251-35a269479413?auto=format&fit=crop&w=1500&q=80');">
         <div class="container" data-aos="fade-up">
             <h1 class="display-4">Tait Draper</h1>
             <p class="lead">Portfolio</p>
@@ -36,21 +36,21 @@
     </section>
 
 
-    <section id="skills" style="background-image: url('https://images.unsplash.com/photo-1519389950473-47ba0277781c?auto=format&fit=crop&w=1500&q=80'); background-size: cover; background-position: center;">
+    <section id="skills" class="home-section" style="background-image: url('https://images.unsplash.com/photo-1519389950473-47ba0277781c?auto=format&fit=crop&w=1500&q=80'); background-size: cover; background-position: center;">
         <div class="container text-center" data-aos="fade-up">
             <h2 class="section-title">My Skills</h2>
             <a href="Skills.html" class="btn btn-primary">View Skills</a>
         </div>
     </section>
 
-    <section id="projects" style="background-image: url('https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1500&q=80'); background-size: cover; background-position: center;">
+    <section id="projects" class="home-section" style="background-image: url('https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1500&q=80'); background-size: cover; background-position: center;">
         <div class="container text-center" data-aos="fade-up">
             <h2 class="section-title">Projects</h2>
             <a href="Projects.html" class="btn btn-primary">See them here!</a>
         </div>
     </section>
 
-    <section id="contact" style="background-image: url('https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1500&q=80'); background-size: cover; background-position: center;">
+    <section id="contact" class="home-section" style="background-image: url('https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1500&q=80'); background-size: cover; background-position: center;">
         <div class="container text-center" data-aos="fade-up">
             <h2 class="section-title">Contact Me</h2>
             <a href="Contact.html" class="btn btn-primary">Contact</a>


### PR DESCRIPTION
## Summary
- make hero and navigation sections larger on the homepage
- add responsive heights so sections scale down on mobile

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847819697148325bdda052cb848a208