### PR TITLE
Add profile image to homepage about section

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
 
     <section id="about" class="home-section" style="background-image: url('https://images.unsplash.com/photo-1521737104218-7fcd68359815?auto=format&fit=crop&w=1500&q=80'); background-size: cover; background-position: center;">
         <div class="container text-center" data-aos="fade-up">
+            <img src="my pic.jpg" class="img-fluid rounded mb-3" style="max-width: 300px;" alt="Photo of Tait">
             <div class="overlay-box">
                 <h2 class="section-title">About Me</h2>
                 <a href="About.html" class="btn btn-primary">Learn More</a>


### PR DESCRIPTION
## Summary
- add profile picture to the About section of the homepage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68478e1d584c8325a4325322f81a764b