### PR TITLE
Add layered photo on home page

### DIFF
--- a/Stylesheet.css
+++ b/Stylesheet.css
@@ -150,3 +150,25 @@ footer p {
         min-height: 30vh;
     }
 }
+
+.about-photo {
+    position: relative;
+    display: inline-block;
+    max-width: 300px;
+}
+
+.about-photo .profile-img {
+    width: 100%;
+    position: relative;
+    z-index: 2;
+    border-radius: 0.25rem;
+}
+
+.about-photo .bg-img {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    width: 100%;
+    z-index: 1;
+    border-radius: 0.25rem;
+}

--- a/index.html
+++ b/index.html
@@ -40,7 +40,10 @@
 
     <section id="about" class="home-section" style="background-image: url('https://images.unsplash.com/photo-1521737104218-7fcd68359815?auto=format&fit=crop&w=1500&q=80'); background-size: cover; background-position: center;">
         <div class="container text-center" data-aos="fade-up">
-            <img src="my pic.jpg" class="img-fluid rounded mb-3" style="max-width: 300px;" alt="Photo of Tait">
+            <div class="about-photo mb-3">
+                <img src="yellow balls copy.png" class="bg-img" alt="">
+                <img src="my pic.jpg" class="img-fluid rounded profile-img" alt="Photo of Tait">
+            </div>
             <div class="overlay-box">
                 <h2 class="section-title">About Me</h2>
                 <a href="About.html" class="btn btn-primary">Learn More</a>


### PR DESCRIPTION
## Summary
- show a second image behind the profile photo on the home page
- style new `about-photo` wrapper for layered images

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_68478f2ffe988325bcd238baba52d452