### PR TITLE
Update About page with resume details

### DIFF
--- a/About.html
+++ b/About.html
@@ -37,13 +37,16 @@
 
     <section class="about-section">
         <div class="container" data-aos="fade-up">
-            <h2 class="section-title text-center">Education</h2>
             <div class="row align-items-center">
-                <div class="col-md-6">
-                    <img src="https://images.unsplash.com/photo-1523580846011-d3a5bc25702b?auto=format&fit=crop&w=800&q=80" class="img-fluid rounded mb-3" alt="Graduation cap">
+                <div class="col-md-6 mb-3 text-center">
+                    <img src="my pic.jpg" class="img-fluid rounded" alt="Tait Draper">
                 </div>
                 <div class="col-md-6">
-                    <p>I graduated from Utah Valley University in May 2025 with a Bachelor's degree in Computer Science.</p>
+                    <h2 class="section-title">Tait Draper</h2>
+                    <p>1083 W 1750 S<br>Lehi, UT 84043<br>(385) 225-2643<br>
+                        <a href="mailto:drapertait@gmail.com">drapertait@gmail.com</a><br>
+                        <a href="https://drapertait.github.io">drapertait.github.io</a>
+                    </p>
                 </div>
             </div>
         </div>
@@ -51,15 +54,119 @@
 
     <section class="about-section">
         <div class="container" data-aos="fade-up">
-            <h2 class="section-title text-center">Work Experience</h2>
-            <div class="row">
-                <div class="col-md-6 mb-4 text-center">
-                    <img src="https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=800&q=80" class="img-fluid rounded mb-3" alt="Software engineering">
-                    <p>Software Engineer in UVU's E2I program building innovative solutions for students and faculty.</p>
+            <h2 class="section-title text-center">Education</h2>
+            <div class="row align-items-center">
+                <div class="col-md-6">
+                    <img src="https://images.unsplash.com/photo-1523580846011-d3a5bc25702b?auto=format&fit=crop&w=800&q=80" class="img-fluid rounded mb-3" alt="Graduation cap">
                 </div>
-                <div class="col-md-6 mb-4 text-center">
-                    <img src="https://images.unsplash.com/photo-1581093588401-eca0b12be479?auto=format&fit=crop&w=800&q=80" class="img-fluid rounded mb-3" alt="Automation testing">
-                    <p>Automation Engineer and QA Engineer for the Church of Jesus Christ of Latter-day Saints ensuring product quality.</p>
+                <div class="col-md-6">
+                    <ul class="list-unstyled">
+                        <li>
+                            <strong>Utah Valley University, Orem - 3.6 GPA</strong><br>
+                            <em>August 2021 - May 2025</em><br>
+                            I studied computer science with a concentration in cybersecurity. This included object-oriented programming in most common languages today, website development, networking, ethical hacking, cryptography, database management, and Linux system management.
+                        </li>
+                        <li class="mt-3">
+                            <strong>Lehi High, Lehi — 3.9 GPA Graduate</strong><br>
+                            <em>August 2016 - June 2019</em><br>
+                            Graduated from Lehi High School with high honors.
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="about-section">
+        <div class="container" data-aos="fade-up">
+            <h2 class="section-title text-center">Experience</h2>
+            <div class="row align-items-center">
+                <div class="col-md-6">
+                    <img src="https://images.unsplash.com/photo-1581093588401-eca0b12be479?auto=format&fit=crop&w=800&q=80" class="img-fluid rounded mb-3" alt="Workplace">
+                </div>
+                <div class="col-md-6">
+                    <ul class="list-unstyled">
+                        <li>
+                            <strong>Church of Jesus Christ of Latter-day Saints, ICS Riverton — Quality Assurance Engineer Intern</strong><br>
+                            <em>August 2024 - Current</em><br>
+                            Quality assurance engineer on a small team. Provided quality assurance and wrote automation tests for API endpoints. Most tests are built in Cypress using JavaScript, while UI automation is done in Playwright. Tested and maintained the AWS database using tools like DynamoDB, S3 bucket and Glue job.
+                        </li>
+                        <li class="mt-3">
+                            <strong>Utah Valley University, Orem, Utah — Software Developer</strong><br>
+                            <em>July 2023 - January 2024</em><br>
+                            Project leader on a small development team focused on delivering affordable software to UVU alumni and locals. This included several projects such as game development and website development.
+                        </li>
+                        <li class="mt-3">
+                            <strong>Intermountain Healthcare, Utah Valley Hospital — Valet Driver</strong><br>
+                            <em>May 2022 - August 2024</em><br>
+                            Parked customer vehicles at the Utah Valley Hospital. Directed customers to their appointments, parked vehicles, managed personal items, and translated around the hospital for Spanish-speaking patients.
+                        </li>
+                        <li class="mt-3">
+                            <strong>Intermountain Healthcare, American Fork Hospital — Receptionist</strong><br>
+                            <em>August 2021 - May 2022</em><br>
+                            A receptionist at the American Fork Hospital. Duties included directing all visitors to the correct location, screening visitors for COVID-19 and other receptionist responsibilities.
+                        </li>
+                        <li class="mt-3">
+                            <strong>Intermountain Healthcare, LDS Children's Hospital & Draper Location — EVS Tech</strong><br>
+                            <em>May 2019 - Jul 2019</em><br>
+                            Environmental Services Tech providing a comfortable and safe healing environment for patients by performing comprehensive housekeeping tasks to ensure clean, sanitary and attractive facilities.
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="about-section">
+        <div class="container" data-aos="fade-up">
+            <h2 class="section-title text-center">Skills &amp; Awards</h2>
+            <div class="row align-items-center">
+                <div class="col-md-6">
+                    <img src="https://images.unsplash.com/photo-1503676260728-1c00da094a0b?auto=format&fit=crop&w=800&q=80" class="img-fluid rounded mb-3" alt="Achievements">
+                </div>
+                <div class="col-md-6">
+                    <h5>Skills</h5>
+                    <ul>
+                        <li>Adobe Photoshop</li>
+                        <li>Premier Pro</li>
+                        <li>Guitarist</li>
+                    </ul>
+                    <h5>Awards</h5>
+                    <ul>
+                        <li>Eagle Scout - 2019</li>
+                        <li>Skills USA National Medalist in technical directing</li>
+                        <li>All-region academic soccer athlete</li>
+                        <li>National Honor Society member</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="about-section">
+        <div class="container" data-aos="fade-up">
+            <h2 class="section-title text-center">Programming Languages &amp; Languages</h2>
+            <div class="row align-items-center">
+                <div class="col-md-6">
+                    <img src="https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=800&q=80" class="img-fluid rounded mb-3" alt="Coding">
+                </div>
+                <div class="col-md-6">
+                    <h5>Programming Languages</h5>
+                    <ul>
+                        <li>Python</li>
+                        <li>HTML</li>
+                        <li>CSS</li>
+                        <li>Javascript</li>
+                        <li>Assembly &amp; Machine</li>
+                        <li>JSON &amp; XML</li>
+                        <li>Java</li>
+                        <li>C++</li>
+                    </ul>
+                    <h5>Languages</h5>
+                    <ul>
+                        <li>Fluent in English</li>
+                        <li>Fluent in Spanish</li>
+                    </ul>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- extend the About page with contact details and resume sections
- add education and work history breakdowns
- include skills, awards, programming languages, and language proficiencies

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6848bc01daf0832586aa311d692fa2d2