### PR TITLE
Fix missing background on Skills page

### DIFF
--- a/Skills.html
+++ b/Skills.html
@@ -28,7 +28,7 @@
         </div>
     </nav>
 
-    <section class="hero" style="background-image: url('https://images.unsplash.com/photo-1517430816045-df4b7de39d81?auto=format&fit=crop&w=1500&q=80');">
+    <section class="hero" style="background-image: url('light theme skills.webp');">
         <div class="container" data-aos="fade-up">
             <h1 class="display-4">Skills</h1>
         </div>


### PR DESCRIPTION
## Summary
- ensure local image used for Skills hero background instead of blocked Unsplash link

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848fa75fdb88325961c9ceb9dda1bb7