### PR TITLE
Fix profile carousel overlay

### DIFF
--- a/Stylesheet.css
+++ b/Stylesheet.css
@@ -232,8 +232,11 @@ footer p {
 
 /* Carousel styles for Deal Breaker page */
 .profile-carousel .carousel-item {
-    display: flex;
     justify-content: center;
+}
+
+.profile-carousel .carousel-item.active {
+    display: flex;
 }
 
 .quote-carousel blockquote {


### PR DESCRIPTION
## Summary
- adjust carousel item CSS so non-active slides are hidden

## Testing
- `npx -y htmlhint dealbreaker.html`

------
https://chatgpt.com/codex/tasks/task_e_685121a469a08325a687a9fff6c04c4b