### PR TITLE
Enhance Deal Breaker login options

### DIFF
--- a/dealbreaker-login.html
+++ b/dealbreaker-login.html
@@ -38,7 +38,19 @@
                     <input type="password" class="form-control" id="password">
                 </div>
                 <button type="submit" class="btn dealbreaker-btn">Sign In</button>
+                <div class="mt-3">
+                    <a href="#" class="btn dealbreaker-btn me-2">Register</a>
+                    <a href="#" class="btn btn-link">Forgot Password?</a>
+                </div>
             </form>
+        </div>
+    </section>
+
+    <section>
+        <div class="container text-center" data-aos="fade-up">
+            <h2 class="mb-3">Beta Testing</h2>
+            <p class="mb-4">Want to explore Deal Breaker without signing up?</p>
+            <a href="#" class="btn dealbreaker-btn">Skip Login &amp; Register</a>
         </div>
     </section>
 


### PR DESCRIPTION
## Summary
- add Register and Forgot Password buttons on the login page
- include a beta testing section with a Skip Login & Register option

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6851d3a82d04832597933aba028dda16