### PR TITLE
Enhance registration with step-based form

### DIFF
--- a/dealbreaker-register.html
+++ b/dealbreaker-register.html
@@ -28,39 +28,65 @@
 
     <section>
         <div class="container" data-aos="fade-up">
-            <form>
-                <div class="mb-3">
-                    <label for="name" class="form-label">Name</label>
-                    <input type="text" class="form-control" id="name" placeholder="Your name">
+            <form id="registrationForm">
+                <div class="form-step">
+                    <div class="mb-3">
+                        <label for="name" class="form-label">Name</label>
+                        <input type="text" class="form-control" id="name" placeholder="Your name">
+                    </div>
+                    <button class="btn dealbreaker-btn next-step">Next</button>
                 </div>
-                <div class="mb-3">
-                    <label for="email" class="form-label">Email</label>
-                    <input type="email" class="form-control" id="email" placeholder="name@example.com">
+                <div class="form-step d-none">
+                    <div class="mb-3">
+                        <label for="email" class="form-label">Email</label>
+                        <input type="email" class="form-control" id="email" placeholder="name@example.com">
+                    </div>
+                    <div class="d-flex justify-content-between">
+                        <button class="btn btn-link prev-step">Back</button>
+                        <button class="btn dealbreaker-btn next-step">Next</button>
+                    </div>
                 </div>
-                <div class="mb-3">
-                    <label for="password" class="form-label">Password</label>
-                    <input type="password" class="form-control" id="password">
+                <div class="form-step d-none">
+                    <div class="mb-3">
+                        <label for="password" class="form-label">Password</label>
+                        <input type="password" class="form-control" id="password">
+                    </div>
+                    <div class="d-flex justify-content-between">
+                        <button class="btn btn-link prev-step">Back</button>
+                        <button class="btn dealbreaker-btn next-step">Next</button>
+                    </div>
                 </div>
-                <div class="mb-3">
-                    <label for="confirmPassword" class="form-label">Confirm Password</label>
-                    <input type="password" class="form-control" id="confirmPassword">
+                <div class="form-step d-none">
+                    <div class="mb-3">
+                        <label for="confirmPassword" class="form-label">Confirm Password</label>
+                        <input type="password" class="form-control" id="confirmPassword">
+                    </div>
+                    <div class="d-flex justify-content-between">
+                        <button class="btn btn-link prev-step">Back</button>
+                        <button class="btn dealbreaker-btn next-step">Next</button>
+                    </div>
                 </div>
-                <div class="mb-3">
-                    <label for="profileImage" class="form-label">Profile Image</label>
-                    <input class="form-control" type="file" id="profileImage">
-                </div>
-                <button type="submit" class="btn dealbreaker-btn">Register</button>
-                <div class="mt-3">
-                    <a href="dealbreaker-login.html" class="btn btn-link">Already have an account? Sign In</a>
+                <div class="form-step d-none">
+                    <div class="mb-3">
+                        <label for="profileImage" class="form-label">Profile Image</label>
+                        <input class="form-control" type="file" id="profileImage">
+                    </div>
+                    <div class="d-flex justify-content-between">
+                        <button class="btn btn-link prev-step">Back</button>
+                        <button type="submit" class="btn dealbreaker-btn">Register</button>
+                    </div>
                 </div>
             </form>
-        </div>
+            <div class="mt-3">
+                <a href="dealbreaker-login.html" class="btn btn-link">Already have an account? Sign In</a>
+            </div>
     </section>
 
     <footer class="text-center">
         <p>&copy; 2024 Deal Breaker</p>
     </footer>
 
+    <script src="dealbreaker-register.js"></script>
     <script>
         AOS.init();
     </script>

--- a/dealbreaker-register.js
+++ b/dealbreaker-register.js
@@ -1,0 +1,29 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const steps = Array.from(document.querySelectorAll('.form-step'));
+    let currentStep = 0;
+
+    function showStep(index) {
+        steps.forEach((step, i) => {
+            step.classList.toggle('d-none', i !== index);
+        });
+    }
+
+    document.getElementById('registrationForm').addEventListener('click', (e) => {
+        if (e.target.classList.contains('next-step')) {
+            e.preventDefault();
+            if (currentStep < steps.length - 1) {
+                currentStep++;
+                showStep(currentStep);
+            }
+        }
+        if (e.target.classList.contains('prev-step')) {
+            e.preventDefault();
+            if (currentStep > 0) {
+                currentStep--;
+                showStep(currentStep);
+            }
+        }
+    });
+
+    showStep(currentStep);
+});


### PR DESCRIPTION
## Summary
- show one question at a time on the Deal Breaker registration page
- add supporting JavaScript to handle stepping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851d5917af483259401932836796e77