### PR TITLE
Enhance Deal Breaker registration UI

### DIFF
--- a/Stylesheet.css
+++ b/Stylesheet.css
@@ -311,3 +311,27 @@ footer p {
     background-color: #ffe6e6;
     color: #f68f9d;
 }
+
+/* Registration form styles */
+.dealbreaker-form {
+    max-width: 500px;
+    margin: 0 auto;
+    padding: 30px;
+    background-color: #ffffff;
+    border-radius: 15px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.dealbreaker-form .form-control {
+    border-radius: 10px;
+    border-color: #ff9a9e;
+}
+
+.dealbreaker-form .form-control:focus {
+    box-shadow: 0 0 0 0.2rem rgba(255, 154, 158, 0.25);
+    border-color: #ff9a9e;
+}
+
+.bg-dealbreaker {
+    background-color: #ff9a9e !important;
+}

--- a/dealbreaker-register.html
+++ b/dealbreaker-register.html
@@ -28,7 +28,10 @@
 
     <section>
         <div class="container" data-aos="fade-up">
-            <form id="registrationForm">
+            <div class="progress mb-4">
+                <div id="formProgress" class="progress-bar bg-dealbreaker" role="progressbar" style="width: 0%" aria-valuemin="0" aria-valuemax="100"></div>
+            </div>
+            <form id="registrationForm" class="dealbreaker-form">
                 <div class="form-step">
                     <div class="mb-3">
                         <label for="name" class="form-label">Name</label>
@@ -80,6 +83,7 @@
             <div class="mt-3">
                 <a href="dealbreaker-login.html" class="btn btn-link">Already have an account? Sign In</a>
             </div>
+        </div>
     </section>
 
     <footer class="text-center">

--- a/dealbreaker-register.js
+++ b/dealbreaker-register.js
@@ -1,11 +1,20 @@
 document.addEventListener('DOMContentLoaded', () => {
     const steps = Array.from(document.querySelectorAll('.form-step'));
+    const progressBar = document.getElementById('formProgress');
     let currentStep = 0;
+
+    function updateProgress(index) {
+        if (progressBar) {
+            const percent = (index / (steps.length - 1)) * 100;
+            progressBar.style.width = `${percent}%`;
+        }
+    }
 
     function showStep(index) {
         steps.forEach((step, i) => {
             step.classList.toggle('d-none', i !== index);
         });
+        updateProgress(index);
     }
 
     document.getElementById('registrationForm').addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- restyle registration page with a progress bar and form card
- add CSS helpers for Deal Breaker forms
- update JS to update progress bar as steps change

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851d6d641988325a67bc2fe168639e9