### PR TITLE
Add basic explore, chat and profile screens

### DIFF
--- a/dealbreaker-app.html
+++ b/dealbreaker-app.html
@@ -30,10 +30,10 @@
 
     <nav class="navbar fixed-bottom navbar-light bg-light border-top">
         <div class="container-fluid justify-content-around">
-            <a class="nav-link text-center" href="#"><i class="bi bi-house-door-fill"></i><br>Home</a>
-            <a class="nav-link text-center" href="#"><i class="bi bi-search"></i><br>Explore</a>
-            <a class="nav-link text-center" href="#"><i class="bi bi-chat-dots-fill"></i><br>Chat</a>
-            <a class="nav-link text-center" href="#"><i class="bi bi-person-fill"></i><br>Profile</a>
+            <a class="nav-link text-center" href="dealbreaker-app.html"><i class="bi bi-house-door-fill"></i><br>Home</a>
+            <a class="nav-link text-center" href="dealbreaker-explore.html"><i class="bi bi-search"></i><br>Explore</a>
+            <a class="nav-link text-center" href="dealbreaker-chat.html"><i class="bi bi-chat-dots-fill"></i><br>Chat</a>
+            <a class="nav-link text-center" href="dealbreaker-profile.html"><i class="bi bi-person-fill"></i><br>Profile</a>
         </div>
     </nav>
 

--- a/dealbreaker-chat.html
+++ b/dealbreaker-chat.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Deal Breaker - Chat</title>
+    <link rel="stylesheet" href="Stylesheet.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+    <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+</head>
+<body class="d-flex flex-column" style="min-height:100vh;">
+    <header class="navbar navbar-dark dealbreaker-nav">
+        <div class="container"><a class="navbar-brand" href="dealbreaker.html">Deal Breaker</a></div>
+    </header>
+
+    <main class="flex-grow-1 d-flex flex-column justify-content-center align-items-center" style="padding-bottom:80px;">
+        <div class="text-center">
+            <h1 class="mb-3">Chat</h1>
+            <p>Start chatting with your matches soon.</p>
+        </div>
+    </main>
+
+    <nav class="navbar fixed-bottom navbar-light bg-light border-top">
+        <div class="container-fluid justify-content-around">
+            <a class="nav-link text-center" href="dealbreaker-app.html"><i class="bi bi-house-door-fill"></i><br>Home</a>
+            <a class="nav-link text-center" href="dealbreaker-explore.html"><i class="bi bi-search"></i><br>Explore</a>
+            <a class="nav-link text-center" href="dealbreaker-chat.html"><i class="bi bi-chat-dots-fill"></i><br>Chat</a>
+            <a class="nav-link text-center" href="dealbreaker-profile.html"><i class="bi bi-person-fill"></i><br>Profile</a>
+        </div>
+    </nav>
+
+
+</body>
+</html>

--- a/dealbreaker-explore.html
+++ b/dealbreaker-explore.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Deal Breaker - Explore</title>
+    <link rel="stylesheet" href="Stylesheet.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+    <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+</head>
+<body class="d-flex flex-column" style="min-height:100vh;">
+    <header class="navbar navbar-dark dealbreaker-nav">
+        <div class="container"><a class="navbar-brand" href="dealbreaker.html">Deal Breaker</a></div>
+    </header>
+
+    <main class="flex-grow-1 d-flex flex-column justify-content-center align-items-center" style="padding-bottom:80px;">
+        <div class="text-center">
+            <h1 class="mb-3">Explore</h1>
+            <p>Browse potential matches coming soon.</p>
+        </div>
+    </main>
+
+    <nav class="navbar fixed-bottom navbar-light bg-light border-top">
+        <div class="container-fluid justify-content-around">
+            <a class="nav-link text-center" href="dealbreaker-app.html"><i class="bi bi-house-door-fill"></i><br>Home</a>
+            <a class="nav-link text-center" href="dealbreaker-explore.html"><i class="bi bi-search"></i><br>Explore</a>
+            <a class="nav-link text-center" href="dealbreaker-chat.html"><i class="bi bi-chat-dots-fill"></i><br>Chat</a>
+            <a class="nav-link text-center" href="dealbreaker-profile.html"><i class="bi bi-person-fill"></i><br>Profile</a>
+        </div>
+    </nav>
+
+
+</body>
+</html>

--- a/dealbreaker-profile.html
+++ b/dealbreaker-profile.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Deal Breaker - Profile</title>
+    <link rel="stylesheet" href="Stylesheet.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+    <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+</head>
+<body class="d-flex flex-column" style="min-height:100vh;">
+    <header class="navbar navbar-dark dealbreaker-nav">
+        <div class="container"><a class="navbar-brand" href="dealbreaker.html">Deal Breaker</a></div>
+    </header>
+
+    <main class="flex-grow-1 d-flex flex-column justify-content-center align-items-center" style="padding-bottom:80px;">
+        <div class="text-center">
+            <h1 class="mb-3">Profile</h1>
+            <p>Manage your personal information here.</p>
+        </div>
+    </main>
+
+    <nav class="navbar fixed-bottom navbar-light bg-light border-top">
+        <div class="container-fluid justify-content-around">
+            <a class="nav-link text-center" href="dealbreaker-app.html"><i class="bi bi-house-door-fill"></i><br>Home</a>
+            <a class="nav-link text-center" href="dealbreaker-explore.html"><i class="bi bi-search"></i><br>Explore</a>
+            <a class="nav-link text-center" href="dealbreaker-chat.html"><i class="bi bi-chat-dots-fill"></i><br>Chat</a>
+            <a class="nav-link text-center" href="dealbreaker-profile.html"><i class="bi bi-person-fill"></i><br>Profile</a>
+        </div>
+    </nav>
+
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- link bottom nav to dedicated pages
- create placeholders for Explore, Chat and Profile screens

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6851e73eb34c8325965b4c74d54c3902