### PR TITLE
Update Deal Breaker nav

### DIFF
--- a/dealbreaker-add-questions.html
+++ b/dealbreaker-add-questions.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Deal Breaker - Explore</title>
+    <title>Deal Breaker - Add Questions</title>
     <link rel="stylesheet" href="Stylesheet.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
@@ -16,15 +16,15 @@
 
     <main class="flex-grow-1 d-flex flex-column justify-content-center align-items-center" style="padding-bottom:80px;">
         <div class="text-center">
-            <h1 class="mb-3">Explore</h1>
-            <p>Browse potential matches coming soon.</p>
+            <h1 class="mb-3">Add Questions</h1>
+            <p>Create or edit the questions that define your deal breakers.</p>
         </div>
     </main>
 
     <nav class="navbar fixed-bottom navbar-light bg-light border-top">
         <div class="container-fluid justify-content-around">
             <a class="nav-link text-center" href="dealbreaker-app.html"><i class="bi bi-house-door-fill"></i><br>Home</a>
-            <a class="nav-link text-center" href="dealbreaker-explore.html"><i class="bi bi-search"></i><br>Explore</a>
+            <a class="nav-link text-center" href="dealbreaker-add-questions.html"><i class="bi bi-plus-circle"></i><br>Add Questions</a>
             <a class="nav-link text-center" href="dealbreaker-chat.html"><i class="bi bi-chat-dots-fill"></i><br>Chat</a>
             <a class="nav-link text-center" href="dealbreaker-profile.html"><i class="bi bi-person-fill"></i><br>Profile</a>
         </div>

--- a/dealbreaker-app.html
+++ b/dealbreaker-app.html
@@ -31,7 +31,7 @@
     <nav class="navbar fixed-bottom navbar-light bg-light border-top">
         <div class="container-fluid justify-content-around">
             <a class="nav-link text-center" href="dealbreaker-app.html"><i class="bi bi-house-door-fill"></i><br>Home</a>
-            <a class="nav-link text-center" href="dealbreaker-explore.html"><i class="bi bi-search"></i><br>Explore</a>
+            <a class="nav-link text-center" href="dealbreaker-add-questions.html"><i class="bi bi-plus-circle"></i><br>Add Questions</a>
             <a class="nav-link text-center" href="dealbreaker-chat.html"><i class="bi bi-chat-dots-fill"></i><br>Chat</a>
             <a class="nav-link text-center" href="dealbreaker-profile.html"><i class="bi bi-person-fill"></i><br>Profile</a>
         </div>

--- a/dealbreaker-chat.html
+++ b/dealbreaker-chat.html
@@ -24,7 +24,7 @@
     <nav class="navbar fixed-bottom navbar-light bg-light border-top">
         <div class="container-fluid justify-content-around">
             <a class="nav-link text-center" href="dealbreaker-app.html"><i class="bi bi-house-door-fill"></i><br>Home</a>
-            <a class="nav-link text-center" href="dealbreaker-explore.html"><i class="bi bi-search"></i><br>Explore</a>
+            <a class="nav-link text-center" href="dealbreaker-add-questions.html"><i class="bi bi-plus-circle"></i><br>Add Questions</a>
             <a class="nav-link text-center" href="dealbreaker-chat.html"><i class="bi bi-chat-dots-fill"></i><br>Chat</a>
             <a class="nav-link text-center" href="dealbreaker-profile.html"><i class="bi bi-person-fill"></i><br>Profile</a>
         </div>

--- a/dealbreaker-profile.html
+++ b/dealbreaker-profile.html
@@ -40,7 +40,7 @@
     <nav class="navbar fixed-bottom navbar-light bg-light border-top">
         <div class="container-fluid justify-content-around">
             <a class="nav-link text-center" href="dealbreaker-app.html"><i class="bi bi-house-door-fill"></i><br>Home</a>
-            <a class="nav-link text-center" href="dealbreaker-explore.html"><i class="bi bi-search"></i><br>Explore</a>
+            <a class="nav-link text-center" href="dealbreaker-add-questions.html"><i class="bi bi-plus-circle"></i><br>Add Questions</a>
             <a class="nav-link text-center" href="dealbreaker-chat.html"><i class="bi bi-chat-dots-fill"></i><br>Chat</a>
             <a class="nav-link text-center" href="dealbreaker-profile.html"><i class="bi bi-person-fill"></i><br>Profile</a>
         </div>


### PR DESCRIPTION
## Summary
- rename `dealbreaker-explore.html` to `dealbreaker-add-questions.html`
- update navigation links across Deal Breaker pages
- show an `Add Questions` option instead of `Explore`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6851ea621bdc8325be95aa1bc63769f1