### PR TITLE
Add questions modal

### DIFF
--- a/dealbreaker-add-questions.html
+++ b/dealbreaker-add-questions.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Deal Breaker - Add Questions</title>
+    <title>Deal Breaker - Questions</title>
     <link rel="stylesheet" href="Stylesheet.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
@@ -16,19 +16,79 @@
 
     <main class="flex-grow-1 d-flex flex-column justify-content-center align-items-center" style="padding-bottom:80px;">
         <div class="text-center">
-            <h1 class="mb-3">Add Questions</h1>
+            <h1 class="mb-3">Questions</h1>
             <p>Create or edit the questions that define your deal breakers.</p>
+        </div>
+
+        <div class="container mt-4" style="max-width:500px;">
+            <div class="list-group">
+                <div class="list-group-item d-flex justify-content-between align-items-center">
+                    <span>Do you want children?</span>
+                    <button class="btn dealbreaker-btn answer-btn" data-question="Do you want children?">Answer</button>
+                </div>
+                <div class="list-group-item d-flex justify-content-between align-items-center">
+                    <span>Are you open to relocating?</span>
+                    <button class="btn dealbreaker-btn answer-btn" data-question="Are you open to relocating?">Answer</button>
+                </div>
+                <div class="list-group-item d-flex justify-content-between align-items-center">
+                    <span>Do you smoke?</span>
+                    <button class="btn dealbreaker-btn answer-btn" data-question="Do you smoke?">Answer</button>
+                </div>
+            </div>
         </div>
     </main>
 
     <nav class="navbar fixed-bottom navbar-light bg-light border-top">
         <div class="container-fluid justify-content-around">
             <a class="nav-link text-center" href="dealbreaker-app.html"><i class="bi bi-house-door-fill"></i><br>Home</a>
-            <a class="nav-link text-center" href="dealbreaker-add-questions.html"><i class="bi bi-plus-circle"></i><br>Add Questions</a>
+            <a class="nav-link text-center" href="dealbreaker-add-questions.html"><i class="bi bi-plus-circle"></i><br>Questions</a>
             <a class="nav-link text-center" href="dealbreaker-chat.html"><i class="bi bi-chat-dots-fill"></i><br>Chat</a>
             <a class="nav-link text-center" href="dealbreaker-profile.html"><i class="bi bi-person-fill"></i><br>Profile</a>
         </div>
     </nav>
+
+    <!-- Answer Modal -->
+    <div class="modal fade" id="answerModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="questionTitle"></h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="answerForm">
+                        <div class="mb-3">
+                            <label for="answerInput" class="form-label">Your Answer</label>
+                            <input type="text" class="form-control" id="answerInput">
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                    <button type="button" class="btn dealbreaker-btn" id="saveAnswer">Save</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+    document.querySelectorAll('.answer-btn').forEach(btn => {
+        btn.addEventListener('click', function(){
+            const question = this.dataset.question;
+            document.getElementById('questionTitle').textContent = question;
+            document.getElementById('answerInput').value = '';
+            const modal = new bootstrap.Modal(document.getElementById('answerModal'));
+            modal.show();
+        });
+    });
+
+    document.getElementById('saveAnswer').addEventListener('click', function(){
+        const answer = document.getElementById('answerInput').value;
+        const modal = bootstrap.Modal.getInstance(document.getElementById('answerModal'));
+        modal.hide();
+        alert('You answered: ' + answer);
+    });
+    </script>
 
 
 </body>

--- a/dealbreaker-app.html
+++ b/dealbreaker-app.html
@@ -31,7 +31,7 @@
     <nav class="navbar fixed-bottom navbar-light bg-light border-top">
         <div class="container-fluid justify-content-around">
             <a class="nav-link text-center" href="dealbreaker-app.html"><i class="bi bi-house-door-fill"></i><br>Home</a>
-            <a class="nav-link text-center" href="dealbreaker-add-questions.html"><i class="bi bi-plus-circle"></i><br>Add Questions</a>
+            <a class="nav-link text-center" href="dealbreaker-add-questions.html"><i class="bi bi-plus-circle"></i><br>Questions</a>
             <a class="nav-link text-center" href="dealbreaker-chat.html"><i class="bi bi-chat-dots-fill"></i><br>Chat</a>
             <a class="nav-link text-center" href="dealbreaker-profile.html"><i class="bi bi-person-fill"></i><br>Profile</a>
         </div>

--- a/dealbreaker-chat.html
+++ b/dealbreaker-chat.html
@@ -24,7 +24,7 @@
     <nav class="navbar fixed-bottom navbar-light bg-light border-top">
         <div class="container-fluid justify-content-around">
             <a class="nav-link text-center" href="dealbreaker-app.html"><i class="bi bi-house-door-fill"></i><br>Home</a>
-            <a class="nav-link text-center" href="dealbreaker-add-questions.html"><i class="bi bi-plus-circle"></i><br>Add Questions</a>
+            <a class="nav-link text-center" href="dealbreaker-add-questions.html"><i class="bi bi-plus-circle"></i><br>Questions</a>
             <a class="nav-link text-center" href="dealbreaker-chat.html"><i class="bi bi-chat-dots-fill"></i><br>Chat</a>
             <a class="nav-link text-center" href="dealbreaker-profile.html"><i class="bi bi-person-fill"></i><br>Profile</a>
         </div>

--- a/dealbreaker-profile.html
+++ b/dealbreaker-profile.html
@@ -40,7 +40,7 @@
     <nav class="navbar fixed-bottom navbar-light bg-light border-top">
         <div class="container-fluid justify-content-around">
             <a class="nav-link text-center" href="dealbreaker-app.html"><i class="bi bi-house-door-fill"></i><br>Home</a>
-            <a class="nav-link text-center" href="dealbreaker-add-questions.html"><i class="bi bi-plus-circle"></i><br>Add Questions</a>
+            <a class="nav-link text-center" href="dealbreaker-add-questions.html"><i class="bi bi-plus-circle"></i><br>Questions</a>
             <a class="nav-link text-center" href="dealbreaker-chat.html"><i class="bi bi-chat-dots-fill"></i><br>Chat</a>
             <a class="nav-link text-center" href="dealbreaker-profile.html"><i class="bi bi-person-fill"></i><br>Profile</a>
         </div>


### PR DESCRIPTION
## Summary
- rename "Add Questions" to "Questions" in navigation
- build new Questions page with sample questions
- allow answering questions via a popup modal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851f02b876483258eeb4a65929b3b5b