### PR TITLE
Add profile management pages and dark mode

### DIFF
--- a/Stylesheet.css
+++ b/Stylesheet.css
@@ -368,3 +368,27 @@ footer p {
 .dealbreaker-progress .progress-bar {
     background: linear-gradient(45deg, #ff9a9e, #fad0c4);
 }
+/* Dark mode styles */
+body.dark-mode {
+    background-color: #121212;
+    color: #f8f9fa;
+}
+
+body.dark-mode .dealbreaker-nav,
+body.dark-mode .navbar {
+    background: #212529 !important;
+}
+
+body.dark-mode .list-group-item {
+    background-color: #343a40;
+    color: #f8f9fa;
+    border-color: #454d55;
+}
+
+body.dark-mode .navbar-light.bg-light {
+    background-color: #212529 !important;
+}
+
+body.dark-mode a.nav-link {
+    color: #f8f9fa !important;
+}

--- a/dealbreaker-app.html
+++ b/dealbreaker-app.html
@@ -37,6 +37,7 @@
         </div>
     </nav>
 
+<script src="theme.js"></script>
 <script>
 const profiles = [
     {
@@ -66,9 +67,17 @@ function nextProfile(){
     currentIndex = (currentIndex + 1) % profiles.length;
     showProfile(currentIndex);
 }
-document.getElementById('likeBtn').addEventListener('click', nextProfile);
+function likeProfile(){
+    const liked = JSON.parse(localStorage.getItem('likedProfiles')) || [];
+    liked.push(profiles[currentIndex]);
+    localStorage.setItem('likedProfiles', JSON.stringify(liked));
+    nextProfile();
+}
+document.getElementById('likeBtn').addEventListener('click', likeProfile);
 document.getElementById('passBtn').addEventListener('click', nextProfile);
 showProfile(currentIndex);
 </script>
+
+
 </body>
 </html>

--- a/dealbreaker-like-history.html
+++ b/dealbreaker-like-history.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Like History</title>
+    <link rel="stylesheet" href="Stylesheet.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+    <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+</head>
+<body class="d-flex flex-column" style="min-height:100vh;">
+    <header class="navbar navbar-dark dealbreaker-nav">
+        <div class="container"><a class="navbar-brand" href="dealbreaker.html">Deal Breaker</a></div>
+    </header>
+
+    <main class="flex-grow-1" style="padding-bottom:80px;">
+        <div class="container mt-4">
+            <h1 class="mb-4 text-center">Like History</h1>
+            <div id="likesList" class="list-group"></div>
+        </div>
+    </main>
+
+    <nav class="navbar fixed-bottom navbar-light bg-light border-top">
+        <div class="container-fluid justify-content-around">
+            <a class="nav-link text-center" href="dealbreaker-app.html"><i class="bi bi-house-door-fill"></i><br>Home</a>
+            <a class="nav-link text-center" href="dealbreaker-add-questions.html"><i class="bi bi-plus-circle"></i><br>Questions</a>
+            <a class="nav-link text-center" href="dealbreaker-chat.html"><i class="bi bi-chat-dots-fill"></i><br>Chat</a>
+            <a class="nav-link text-center" href="dealbreaker-profile.html"><i class="bi bi-person-fill"></i><br>Profile</a>
+        </div>
+    </nav>
+
+    <script src="theme.js"></script>
+    <script>
+    document.addEventListener('DOMContentLoaded', function(){
+        const likes = JSON.parse(localStorage.getItem('likedProfiles')) || [];
+        const list = document.getElementById('likesList');
+        if(likes.length === 0){
+            list.innerHTML = '<p class="text-center">No likes yet.</p>';
+        } else {
+            likes.forEach(p => {
+                const item = document.createElement('div');
+                item.className = 'list-group-item';
+                item.innerHTML = `<div class="d-flex align-items-center"><img src="${p.img}" alt="" style="width:40px;height:40px;object-fit:cover;border-radius:50%;" class="me-3"><span>${p.name}</span></div>`;
+                list.appendChild(item);
+            });
+        }
+    });
+    </script>
+</body>
+</html>

--- a/dealbreaker-my-profile.html
+++ b/dealbreaker-my-profile.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>My Profile</title>
+    <link rel="stylesheet" href="Stylesheet.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+    <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+</head>
+<body class="d-flex flex-column" style="min-height:100vh;">
+    <header class="navbar navbar-dark dealbreaker-nav">
+        <div class="container"><a class="navbar-brand" href="dealbreaker.html">Deal Breaker</a></div>
+    </header>
+
+    <main class="flex-grow-1 d-flex flex-column align-items-center" style="padding-bottom:80px;">
+        <div class="text-center mt-4">
+            <h1 class="mb-3">My Profile</h1>
+            <p class="mb-4">Update your details.</p>
+        </div>
+        <div class="w-100" style="max-width:500px;">
+            <form id="profileForm">
+                <div class="mb-3">
+                    <label for="nameInput" class="form-label">Name</label>
+                    <input type="text" class="form-control" id="nameInput">
+                </div>
+                <div class="mb-3">
+                    <label for="bioInput" class="form-label">Bio</label>
+                    <textarea class="form-control" id="bioInput" rows="3"></textarea>
+                </div>
+                <button type="button" class="btn dealbreaker-btn" id="saveProfile">Save</button>
+            </form>
+        </div>
+    </main>
+
+    <nav class="navbar fixed-bottom navbar-light bg-light border-top">
+        <div class="container-fluid justify-content-around">
+            <a class="nav-link text-center" href="dealbreaker-app.html"><i class="bi bi-house-door-fill"></i><br>Home</a>
+            <a class="nav-link text-center" href="dealbreaker-add-questions.html"><i class="bi bi-plus-circle"></i><br>Questions</a>
+            <a class="nav-link text-center" href="dealbreaker-chat.html"><i class="bi bi-chat-dots-fill"></i><br>Chat</a>
+            <a class="nav-link text-center" href="dealbreaker-profile.html"><i class="bi bi-person-fill"></i><br>Profile</a>
+        </div>
+    </nav>
+
+    <script src="theme.js"></script>
+    <script>
+    document.addEventListener('DOMContentLoaded', function(){
+        const data = JSON.parse(localStorage.getItem('myProfile')) || {name:'', bio:''};
+        document.getElementById('nameInput').value = data.name;
+        document.getElementById('bioInput').value = data.bio;
+    });
+    document.getElementById('saveProfile').addEventListener('click', function(){
+        const data = {
+            name: document.getElementById('nameInput').value,
+            bio: document.getElementById('bioInput').value
+        };
+        localStorage.setItem('myProfile', JSON.stringify(data));
+        alert('Profile saved');
+    });
+    </script>
+</body>
+</html>

--- a/dealbreaker-profile.html
+++ b/dealbreaker-profile.html
@@ -21,13 +21,13 @@
         </div>
         <div class="w-100" style="max-width: 400px;">
             <div class="list-group">
-                <a href="#" class="list-group-item list-group-item-action d-flex align-items-center">
+                <a href="dealbreaker-my-profile.html" class="list-group-item list-group-item-action d-flex align-items-center">
                     <i class="bi bi-person me-3"></i> My Profile
                 </a>
-                <a href="#" class="list-group-item list-group-item-action d-flex align-items-center">
+                <a href="dealbreaker-like-history.html" class="list-group-item list-group-item-action d-flex align-items-center">
                     <i class="bi bi-clock-history me-3"></i> Like History
                 </a>
-                <a href="#" class="list-group-item list-group-item-action d-flex align-items-center">
+                <a href="dealbreaker-settings.html" class="list-group-item list-group-item-action d-flex align-items-center">
                     <i class="bi bi-gear me-3"></i> Settings
                 </a>
                 <a href="#" class="list-group-item list-group-item-action d-flex align-items-center">
@@ -46,6 +46,7 @@
         </div>
     </nav>
 
+<script src="theme.js"></script>
 
 </body>
 </html>

--- a/dealbreaker-settings.html
+++ b/dealbreaker-settings.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Settings</title>
+    <link rel="stylesheet" href="Stylesheet.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+    <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+</head>
+<body class="d-flex flex-column" style="min-height:100vh;">
+    <header class="navbar navbar-dark dealbreaker-nav">
+        <div class="container"><a class="navbar-brand" href="dealbreaker.html">Deal Breaker</a></div>
+    </header>
+
+    <main class="flex-grow-1" style="padding-bottom:80px;">
+        <div class="container mt-4" style="max-width:500px;">
+            <h1 class="mb-4 text-center">Settings</h1>
+            <div class="form-check form-switch">
+                <input class="form-check-input" type="checkbox" id="darkModeToggle">
+                <label class="form-check-label" for="darkModeToggle">Dark Mode</label>
+            </div>
+            <button class="btn btn-secondary mt-3" id="clearLikes">Clear Like History</button>
+        </div>
+    </main>
+
+    <nav class="navbar fixed-bottom navbar-light bg-light border-top">
+        <div class="container-fluid justify-content-around">
+            <a class="nav-link text-center" href="dealbreaker-app.html"><i class="bi bi-house-door-fill"></i><br>Home</a>
+            <a class="nav-link text-center" href="dealbreaker-add-questions.html"><i class="bi bi-plus-circle"></i><br>Questions</a>
+            <a class="nav-link text-center" href="dealbreaker-chat.html"><i class="bi bi-chat-dots-fill"></i><br>Chat</a>
+            <a class="nav-link text-center" href="dealbreaker-profile.html"><i class="bi bi-person-fill"></i><br>Profile</a>
+        </div>
+    </nav>
+
+    <script src="theme.js"></script>
+    <script>
+    document.addEventListener('DOMContentLoaded', function(){
+        const toggle = document.getElementById('darkModeToggle');
+        toggle.checked = localStorage.getItem('theme') === 'dark';
+        toggle.addEventListener('change', function(){
+            toggleTheme(this.checked);
+        });
+        document.getElementById('clearLikes').addEventListener('click', function(){
+            localStorage.removeItem('likedProfiles');
+            alert('Like history cleared');
+        });
+    });
+    </script>
+</body>
+</html>

--- a/theme.js
+++ b/theme.js
@@ -1,0 +1,15 @@
+function applyTheme(){
+    const theme = localStorage.getItem('theme');
+    if(theme === 'dark'){
+        document.body.classList.add('dark-mode');
+    } else {
+        document.body.classList.remove('dark-mode');
+    }
+}
+
+function toggleTheme(isDark){
+    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    applyTheme();
+}
+
+document.addEventListener('DOMContentLoaded', applyTheme);


### PR DESCRIPTION
## Summary
- implement dark mode support in `Stylesheet.css`
- update swipe page to store likes and include theme script
- update profile list to link to new pages
- add `theme.js` for handling theme preference
- add new pages: My Profile, Like History and Settings

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68585161a0f48325acdce16791318ec5