### PR TITLE
Remove scrolling from home and questions pages

### DIFF
--- a/Stylesheet.css
+++ b/Stylesheet.css
@@ -8,6 +8,12 @@ body {
     line-height: 1.6;
 }
 
+/* Utility class for full-screen pages without scrolling */
+.full-screen {
+    height: 100vh;
+    overflow: hidden;
+}
+
 nav.navbar {
     background-color: #000 !important;
     padding-top: 20px;

--- a/dealbreaker-add-questions.html
+++ b/dealbreaker-add-questions.html
@@ -9,7 +9,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
     <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
 </head>
-<body class="d-flex flex-column" style="min-height:100vh;">
+<body class="d-flex flex-column full-screen">
     <header class="navbar navbar-dark dealbreaker-nav">
         <div class="container"><a class="navbar-brand" href="dealbreaker.html">Deal Breaker</a></div>
     </header>

--- a/dealbreaker-app.html
+++ b/dealbreaker-app.html
@@ -9,7 +9,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
     <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
 </head>
-<body class="d-flex flex-column" style="min-height:100vh;">
+<body class="d-flex flex-column full-screen">
     <header class="navbar navbar-dark dealbreaker-nav">
         <div class="container"><a class="navbar-brand" href="dealbreaker.html">Deal Breaker</a></div>
     </header>


### PR DESCRIPTION
## Summary
- prevent scrolling by adding a `full-screen` utility class in `Stylesheet.css`
- apply `full-screen` body styling on the Deal Breaker home and Questions pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858554646c8832593f154a258579330