### PR TITLE
Add construction images to contracting page

### DIFF
--- a/contractor.html
+++ b/contractor.html
@@ -51,6 +51,20 @@
         </div>
     </section>
 
+    <section>
+        <div class="container" data-aos="fade-up">
+            <h2 class="section-title text-center">Project Gallery</h2>
+            <div class="row">
+                <div class="col-md-6 mb-4">
+                    <img src="https://source.unsplash.com/800x600/?deck,construction" class="img-fluid rounded" alt="Building a deck">
+                </div>
+                <div class="col-md-6 mb-4">
+                    <img src="https://source.unsplash.com/800x600/?painting,walls" class="img-fluid rounded" alt="Painting walls">
+                </div>
+            </div>
+        </div>
+    </section>
+
     <footer class="text-center">
         <p>&copy; 2024 by Tait Draper. All rights reserved.</p>
         <p>Made with <a href="ProjectsInProgress.html">❤️</a> by Tait Draper</p>


### PR DESCRIPTION
## Summary
- extend contracting page with a new **Project Gallery** section
- add images of deck building and wall painting sourced from Unsplash

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688500cedfe08325bbe77798e03d664f