### PR TITLE
Refresh contractor color palette

### DIFF
--- a/Stylesheet.css
+++ b/Stylesheet.css
@@ -401,23 +401,34 @@ body.dark-mode a.nav-link {
 
 /* Contractor Finder styles */
 .contractor-nav {
-    background: linear-gradient(45deg, #8B4513, #A0522D) !important;
+    background-color: #ffffff !important;
+    border-bottom: 4px solid #4CBB17;
 }
 
 .contractor-nav .navbar-brand {
     font-weight: 700;
     font-size: 1.75rem;
+    color: #001f3f !important;
+}
+
+.contractor-nav .nav-link {
+    color: #001f3f !important;
+}
+
+.contractor-nav .nav-link:hover,
+.contractor-nav .nav-link.active {
+    color: #4CBB17 !important;
 }
 
 .contractor-btn {
-    background-color: #A0522D;
-    border-color: #A0522D;
+    background-color: #4CBB17;
+    border-color: #4CBB17;
     color: #fff;
 }
 
 .contractor-btn:hover {
-    background-color: #8B4513;
-    border-color: #8B4513;
+    background-color: #001f3f;
+    border-color: #001f3f;
 }
 
 .contractor-form {
@@ -429,16 +440,17 @@ body.dark-mode a.nav-link {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 
+
 .contractor-form .form-control,
 .contractor-form .form-select {
     border-radius: 10px;
-    border-color: #A0522D;
+    border-color: #001f3f;
 }
 
 .contractor-form .form-control:focus,
 .contractor-form .form-select:focus {
-    box-shadow: 0 0 0 0.2rem rgba(160, 82, 45, 0.25);
-    border-color: #A0522D;
+    box-shadow: 0 0 0 0.2rem rgba(76, 187, 23, 0.25);
+    border-color: #4CBB17;
 }
 
 .contractor-hero {
@@ -456,14 +468,16 @@ body.dark-mode a.nav-link {
     left: 0;
     width: 100%;
     height: 100%;
-    background: rgba(139, 69, 19, 0.5);
+    background: rgba(0, 31, 63, 0.5);
     z-index: 0;
 }
 
 .contractor-hero .overlay-box {
     position: relative;
     z-index: 1;
-    background-color: rgba(255, 255, 255, 0.8);
-    color: #333;
+    background-color: rgba(255, 255, 255, 0.9);
+    color: #001f3f;
+    border: 2px solid #FFD700;
     border-radius: 15px;
+    padding: 30px;
 }


### PR DESCRIPTION
## Summary
- lighten contractor layout with a mostly white scheme
- add kelly green, navy and yellow accents to buttons, nav and hero overlay

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6885073631308325b74d35d678aa2687