### PR TITLE
Adjust contractor pages text contrast

### DIFF
--- a/contractor-about.html
+++ b/contractor-about.html
@@ -8,7 +8,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
 </head>
-<body>
+<body class="contractor-page">
     <nav class="navbar navbar-expand-lg contractor-nav navbar-dark">
         <div class="container">
             <a class="navbar-brand" href="contractor.html">Contractor Finder</a>
@@ -36,5 +36,6 @@
     <footer class="text-center">
         <p>&copy; 2024 Contractor Finder. All rights reserved.</p>
     </footer>
+    <script src="contractor-text-contrast.js"></script>
 </body>
 </html>

--- a/contractor-register.html
+++ b/contractor-register.html
@@ -10,7 +10,7 @@
     <link href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.js"></script>
 </head>
-<body>
+<body class="contractor-page">
     <nav class="navbar navbar-expand-lg contractor-nav navbar-dark">
         <div class="container">
             <a class="navbar-brand" href="contractor.html">Contractor Finder</a>
@@ -56,6 +56,7 @@
     <footer class="text-center">
         <p>&copy; 2024 Contractor Finder. All rights reserved.</p>
     </footer>
+    <script src="contractor-text-contrast.js"></script>
 
     <script>
         AOS.init();

--- a/contractor-services.html
+++ b/contractor-services.html
@@ -8,7 +8,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
 </head>
-<body>
+<body class="contractor-page">
     <nav class="navbar navbar-expand-lg contractor-nav navbar-dark">
         <div class="container">
             <a class="navbar-brand" href="contractor.html">Contractor Finder</a>
@@ -36,5 +36,6 @@
     <footer class="text-center">
         <p>&copy; 2024 Contractor Finder. All rights reserved.</p>
     </footer>
+    <script src="contractor-text-contrast.js"></script>
 </body>
 </html>

--- a/contractor-text-contrast.js
+++ b/contractor-text-contrast.js
@@ -1,0 +1,33 @@
+function setOppositeTextColor() {
+    const style = window.getComputedStyle(document.body);
+    const bgColor = style.backgroundColor.trim();
+    // parse rgb/rgba or hex
+    let r, g, b;
+    if (bgColor.startsWith('#')) {
+        const hex = bgColor.slice(1);
+        if (hex.length === 3) {
+            r = parseInt(hex[0] + hex[0], 16);
+            g = parseInt(hex[1] + hex[1], 16);
+            b = parseInt(hex[2] + hex[2], 16);
+        } else if (hex.length === 6) {
+            r = parseInt(hex.slice(0,2), 16);
+            g = parseInt(hex.slice(2,4), 16);
+            b = parseInt(hex.slice(4,6), 16);
+        }
+    } else {
+        const match = bgColor.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+        if (match) {
+            r = parseInt(match[1], 10);
+            g = parseInt(match[2], 10);
+            b = parseInt(match[3], 10);
+        }
+    }
+    if (r === undefined) return;
+    const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+    const textColor = brightness > 125 ? '#000000' : '#ffffff';
+    document.body.style.color = textColor;
+}
+
+if (document.body.classList.contains('contractor-page')) {
+    document.addEventListener('DOMContentLoaded', setOppositeTextColor);
+}

--- a/contractor-work.html
+++ b/contractor-work.html
@@ -8,7 +8,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
 </head>
-<body>
+<body class="contractor-page">
     <nav class="navbar navbar-expand-lg contractor-nav navbar-dark">
         <div class="container">
             <a class="navbar-brand" href="contractor.html">Contractor Finder</a>
@@ -36,5 +36,6 @@
     <footer class="text-center">
         <p>&copy; 2024 Contractor Finder. All rights reserved.</p>
     </footer>
+    <script src="contractor-text-contrast.js"></script>
 </body>
 </html>

--- a/contractor.html
+++ b/contractor.html
@@ -10,7 +10,7 @@
     <link href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.js"></script>
 </head>
-<body>
+<body class="contractor-page">
     <nav class="navbar navbar-expand-lg contractor-nav navbar-dark">
         <div class="container">
             <a class="navbar-brand" href="contractor.html">Contractor Finder</a>
@@ -72,5 +72,6 @@
     <script>
         AOS.init();
     </script>
+    <script src="contractor-text-contrast.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure contractor page `<body>` tags use `contractor-page` class
- create `contractor-text-contrast.js` to calculate contrast for body text
- include the script on all contractor pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688508cefd608325a9d40fc9802d21bf